### PR TITLE
Changed header to match case

### DIFF
--- a/translate_webhook_to_discord.php
+++ b/translate_webhook_to_discord.php
@@ -6,7 +6,7 @@ header("Content-type: application/json; charset=utf-8");
 
 $headers = getallheaders();
 
-$event_type = $headers["X-Hacknplan-Event"];
+$event_type = $headers["X-HacknPlan-Event"];
 
 $json = file_get_contents('php://input');
 


### PR DESCRIPTION
As per https://hacknplan.com/knowledge-base/webhooks/ the header name has a change in the case from what is in the code. Otherwise all actions are received as empty.